### PR TITLE
Build on macos

### DIFF
--- a/src/cxx_stubs/SFFtp_stub.cpp
+++ b/src/cxx_stubs/SFFtp_stub.cpp
@@ -29,55 +29,6 @@
 #include "SFTime_stub.hpp"
 
 
-static const sf::Ftp::Response::Status ml_table_sfFtpStatus[] = {
-    sf::Ftp::Response::RestartMarkerReply,
-    sf::Ftp::Response::ServiceReadySoon,
-    sf::Ftp::Response::DataConnectionAlreadyOpened,
-    sf::Ftp::Response::OpeningDataConnection,
-    sf::Ftp::Response::Ok,
-    sf::Ftp::Response::PointlessCommand,
-    sf::Ftp::Response::SystemStatus,
-    sf::Ftp::Response::DirectoryStatus,
-    sf::Ftp::Response::FileStatus,
-    sf::Ftp::Response::HelpMessage,
-    sf::Ftp::Response::SystemType,
-    sf::Ftp::Response::ServiceReady,
-    sf::Ftp::Response::ClosingConnection,
-    sf::Ftp::Response::DataConnectionOpened,
-    sf::Ftp::Response::ClosingDataConnection,
-    sf::Ftp::Response::EnteringPassiveMode,
-    sf::Ftp::Response::LoggedIn,
-    sf::Ftp::Response::FileActionOk,
-    sf::Ftp::Response::DirectoryOk,
-    sf::Ftp::Response::NeedPassword,
-    sf::Ftp::Response::NeedAccountToLogIn,
-    sf::Ftp::Response::NeedInformation,
-    sf::Ftp::Response::ServiceUnavailable,
-    sf::Ftp::Response::DataConnectionUnavailable,
-    sf::Ftp::Response::TransferAborted,
-    sf::Ftp::Response::FileActionAborted,
-    sf::Ftp::Response::LocalError,
-    sf::Ftp::Response::InsufficientStorageSpace,
-    sf::Ftp::Response::CommandUnknown,
-    sf::Ftp::Response::ParametersUnknown,
-    sf::Ftp::Response::CommandNotImplemented,
-    sf::Ftp::Response::BadCommandSequence,
-    sf::Ftp::Response::ParameterNotImplemented,
-    sf::Ftp::Response::NotLoggedIn,
-    sf::Ftp::Response::NeedAccountToStore,
-    sf::Ftp::Response::FileUnavailable,
-    sf::Ftp::Response::PageTypeUnknown,
-    sf::Ftp::Response::NotEnoughMemory,
-    sf::Ftp::Response::FilenameNotAllowed,
-    sf::Ftp::Response::InvalidResponse,
-    sf::Ftp::Response::ConnectionFailed,
-    sf::Ftp::Response::ConnectionClosed,
-    sf::Ftp::Response::InvalidFile,
-};
-
-#define SfFtpStatus_val(v) \
-    (ml_table_sfFtpStatus[Long_val(v)])
-
 
 
 value

--- a/src/cxx_stubs/SFTransform_stub.cpp
+++ b/src/cxx_stubs/SFTransform_stub.cpp
@@ -44,16 +44,16 @@ void finalize_sfTransform_oo(value v)
 
 char id_sf_trans[] = "sf::Transform class";
 static struct custom_operations sfTransform_custom_ops = {
-    identifier:  id_sf_trans,
+    .identifier =  id_sf_trans,
     /*
     finalize:    custom_finalize_default,
     */
-    finalize:    finalize_sfTransform_oo,
+    .finalize =    finalize_sfTransform_oo,
 
-    compare:     custom_compare_default,
-    hash:        custom_hash_default,
-    serialize:   custom_serialize_default,
-    deserialize: custom_deserialize_default
+    .compare =     custom_compare_default,
+    .hash =        custom_hash_default,
+    .serialize =   custom_serialize_default,
+    .deserialize = custom_deserialize_default
 };
 
 value Val_sfTransform(sf::Transform *trans)

--- a/src/cxx_stubs/SFWindow_stub.cpp
+++ b/src/cxx_stubs/SFWindow_stub.cpp
@@ -85,7 +85,7 @@ caml_sfWindow_createFromHandle(value ml_handle, value ml_settings)
 
     sf::Window *window;
     window = new sf::Window;
-    window->create(Nativeint_val(ml_handle), settings);
+    window->create((sf::WindowHandle)Nativeint_val(ml_handle), settings);
 
     CAMLlocal1(ml_window);
     ml_window = caml_alloc_final(2, caml_sfWindow_destroy, 0, 1);
@@ -290,7 +290,7 @@ CAMLextern_C value
 caml_sfWindow_getSystemHandle(value win)
 {
     sf::WindowHandle handle = SfWindow_val(win)->getSystemHandle();
-    return caml_copy_nativeint(handle);
+    return caml_copy_nativeint((intnat)handle);
 }
 
 CAMLextern_C value


### PR DESCRIPTION
A few tweaks necessary to build the library on maOS:
- `sf::WindowHandle` is `void*`, a cast is necessary
- A few tweaks to build with Clang