### PR TITLE
Silence "no cmx file found in path" warnings for several modules when using opam and Dune

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -801,7 +801,7 @@ install_cxx: $(CMI_INTRF) $(SFML_STUBS) META_cxx/META
 	$(INSTALL_FILE) META_cxx/META $(PREFIX)
 	$(INSTALL_FILE) *.mli $(PREFIX)
 	$(INSTALL_FILE) libsfml_*_stubs.a sfml_*.a $(PREFIX)
-	$(INSTALL_FILE) *.cmi sfml_*.cma sfml_*.cmxa $(PREFIX)
+	$(INSTALL_FILE) *.cm[ixo] sfml_*.cma sfml_*.cmxa $(PREFIX)
 	if [ "`ls sfml_*.cmxs 2> /dev/null`" != "" ]; then\
 	 $(INSTALL_EXE) sfml_*.cmxs $(PREFIX); fi
 	$(INSTALL_EXE) dllsfml_*_stubs.so $(DLL_PREFIX)
@@ -816,7 +816,7 @@ install_c: $(CMI_INTRF) $(CSFML_STUBS) META_c/META
 	$(INSTALL_FILE) META_c/META $(PREFIX)
 	$(INSTALL_FILE) *.mli $(PREFIX)
 	$(INSTALL_FILE) libcsfml_*_stubs.a csfml_*.a $(PREFIX)
-	$(INSTALL_FILE) *.cmi csfml_*.cma csfml_*.cmxa $(PREFIX)
+	$(INSTALL_FILE) *.cm[ixo] csfml_*.cma csfml_*.cmxa $(PREFIX)
 	if [ "`ls csfml_*.cmxs 2> /dev/null`" != "" ]; then\
 	 $(INSTALL_EXE) csfml_*.cmxs $(PREFIX); fi
 	$(INSTALL_EXE) dllcsfml_*_stubs.so $(DLL_PREFIX)
@@ -828,10 +828,10 @@ install_c: $(CMI_INTRF) $(CSFML_STUBS) META_c/META
 .PHONY: findinstall findinstall_c findinstall_cxx
 findinstall: findinstall_cxx
 findinstall_cxx: META_cxx/META
-	$(OCAMLFIND) install sfml $< *.cma *.cmxa *.cmxs *.cmi *.mli *.so *.a
+	$(OCAMLFIND) install sfml $< *.cm[aixo] *.cmxa *.cmxs *.mli *.so *.a
 
 findinstall_c: META_c/META
-	$(OCAMLFIND) install sfml $< *.cma *.cmxa *.cmxs *.cmi *.mli *.so *.a
+	$(OCAMLFIND) install sfml $< *.cm[aixo] *.cmxa *.cmxs *.mli *.so *.a
 
 
 


### PR DESCRIPTION
When using the `sfml` package pinned to the current master branch yields the following errors:

```
File "_none_", line 1:
Warning 58: no cmx file was found in path for module SFColor, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module SFContextSettings, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module SFRenderWindow, and its interface was not compiled with -opaque
File "_none_", line 1:
Warning 58: no cmx file was found in path for module SFStyle, and its interface was not compiled with -opaque
Done: 15/18 (jobs: 1)
```

After applying https://github.com/reykjalin/ocaml-sfml/commit/5d1accc856aa2facc58eb41ed88991db107edd2a, based on @Julow's suggestion in https://github.com/fccm/ocaml-sfml/pull/2#issuecomment-705618382 the warnings no longer appear.

To test this version of `sfml` you can `opam pin sfml git@github.com:reykjalin/ocaml-sfml.git#add-missing-implementation-files` and then `opam install sfml`.