### PR TITLE
Add setSize functions to the SFView bindings

### DIFF
--- a/src/SFView.ml
+++ b/src/SFView.ml
@@ -7,6 +7,10 @@ external setCenter: view:t -> center:float * float -> unit
   = "caml_sfView_setCenter2"
 external setCenter2: view:t -> x:float -> y:float -> unit
   = "caml_sfView_setCenter"
+external setSize: view:t -> size:float * float -> unit
+  = "caml_sfView_setSize2"
+external setSize2: view:t -> width:float -> height:float -> unit
+  = "caml_sfView_setSize"
 external move: view:t -> offset:float * float -> unit
   = "caml_sfView_move2"
 external move2: view:t -> offsetX:float -> offsetY:float -> unit

--- a/src/c_stubs/SFView_cstub.c
+++ b/src/c_stubs/SFView_cstub.c
@@ -81,6 +81,20 @@ caml_sfView_setCenter2(value view, value center)
 }
 
 CAMLprim value
+caml_sfView_setSize(value view, value width, value height)
+{
+	sfView_setSize(SfView_val(view), SfVector2f_val2(width, height));
+	return Val_unit;
+}
+
+CAMLprim value
+caml_sfView_setSize2(value view, value size)
+{
+	sfView_setSize(SfView_val(view), SfVector2f_val(size));
+	return Val_unit;
+}
+
+CAMLprim value
 caml_sfView_move(value view, value offsetX, value offsetY)
 {
     sfView_move(SfView_val(view), SfVector2f_val2(offsetX, offsetY));

--- a/src/cxx_stubs/SFView_stub.cpp
+++ b/src/cxx_stubs/SFView_stub.cpp
@@ -112,6 +112,22 @@ caml_sfView_setCenter2(value view, value center)
 }
 
 CAMLextern_C value
+caml_sfView_setSize(value view, value width, value height)
+{
+	sfView_owner_guard("setSize", view);
+	SfView_val(view)->setSize(SfVector2f_val2(width, height));
+	return Val_unit;
+}
+
+CAMLextern_C value
+caml_sfView_setSize2(value view, value size)
+{
+	sfView_owner_guard("setSize2", view);
+	SfView_val(view)->setSize(SfVector2f_val(size));
+	return Val_unit;
+}
+
+CAMLextern_C value
 caml_sfView_move(value view, value offsetX, value offsetY)
 {
     sfView_owner_guard("move", view);


### PR DESCRIPTION
#### Proposed changes

* Add `SFView.setSize` and `SFView.setSize2` functions as options to change the size of the provided view.

The new bindings pretty much just copy what the pre-existing `setCenter` bindings already do for `SFView`s.

Working example available [here](https://git.sr.ht/~reykjalin/ocamledit/tree/4e3d4679394c7719f469f26704dfbf155fd77568/ocamledit.ml#L43-45).


#### Possible caveats

I haven't tested the C stubs because I can't build the C stubs (see #5), so they might need some work, but my assumption is that they work since the functions pretty much mirror the `setCenter` functions.