### PR TITLE
Add binding to sf::RenderWindow::setMouseCursor

### DIFF
--- a/src/SFRenderWindow.ml
+++ b/src/SFRenderWindow.ml
@@ -43,6 +43,7 @@ external setSize2: t -> width:int -> height:int -> unit
 
 external setMouseCursorVisible: t -> show:bool -> unit = "caml_sfRenderWindow_setMouseCursorVisible"
 external setMouseCursorGrabbed: t -> grabbed:bool -> unit = "caml_sfRenderWindow_setMouseCursorGrabbed"
+external setMouseCursor: t -> cursor:SFCursor.t -> unit = "caml_sfRenderWindow_setMouseCursor"
 external setVisible: t -> visible:bool -> unit = "caml_sfRenderWindow_setVisible"
 external setKeyRepeatEnabled: t -> enabled:bool -> unit = "caml_sfRenderWindow_setKeyRepeatEnabled"
 external setActive: t -> active:bool -> unit = "caml_sfRenderWindow_setActive"

--- a/src/cxx_stubs/SFRenderWindow_stub.cpp
+++ b/src/cxx_stubs/SFRenderWindow_stub.cpp
@@ -36,6 +36,7 @@
 #include "SFView_stub.hpp"
 #include "SFEvent_stub.hpp"
 #include "SFColor_stub.hpp"
+#include "SFCursor_stub.hpp"
 #include "SFImage_stub.hpp"
 #include "SFText_stub.hpp"
 #include "SFSprite_stub.hpp"
@@ -263,6 +264,13 @@ CAMLextern_C value
 caml_sfRenderWindow_setMouseCursorGrabbed(value win, value grabbed)
 {
     SfRenderWindow_val(win)->setMouseCursorGrabbed(Bool_val(grabbed));
+    return Val_unit;
+}
+
+CAMLextern_C value
+caml_sfRenderWindow_setMouseCursor(value win, value cursor)
+{
+    SfRenderWindow_val(win)->setMouseCursor(*SfCursor_val(cursor));
     return Val_unit;
 }
 

--- a/src/oo_sfml_graphics.ml
+++ b/src/oo_sfml_graphics.ml
@@ -387,6 +387,7 @@ class render_window
     method set_mouse_cursor_invisible () = SFRenderWindow.setMouseCursorVisible this ~show:false
     method set_mouse_cursor_grabbed () = SFRenderWindow.setMouseCursorGrabbed this ~grabbed:true
     method set_mouse_cursor_ungrabbed () = SFRenderWindow.setMouseCursorGrabbed this ~grabbed:false
+    method set_mouse_cursor ~cursor = SFRenderWindow.setMouseCursor this ~cursor
     method set_visible ~visible = SFRenderWindow.setVisible this ~visible
     method set_key_repeat_enabled ~enabled = SFRenderWindow.setKeyRepeatEnabled this ~enabled
     method set_active ~active = SFRenderWindow.setActive this ~active


### PR DESCRIPTION

#### Proposed changes

* Adds a binding to `sf::RenderWindow::setMouseCursor` for `SFRenderWindow`.
* Adds OO bindings to `sf::RenderWindow::setMouseCursor` for `render_window`.

Mirrors the implementation for `SFWindow`'s `setMouseCursor`. Working example available [here](https://git.sr.ht/~reykjalin/ocamledit/commit/d805d2cd4a8788a0c17b66d3acf33d59f3daa241).

#### Caveat

* Does not contain C bindings to this function.
* The OO bindings have not been tested.